### PR TITLE
Add custom product page support 

### DIFF
--- a/pilot-service-api.yaml
+++ b/pilot-service-api.yaml
@@ -219,7 +219,7 @@ components:
         target_custom_product_page:
           type: string
           enum: [APPLE_APP_CPP]
-          description: predefined formats of ads templates. APPLE_APP_CPP will include screenshot, app preview video, app icon, description, localized description. If set, image_configs will be ignored.
+          description: predefined formats of ads templates. APPLE_APP_CPP will include screenshot, app preview video, app icon, description in target language. If set, image_configs will be ignored.
         image_configs:
           type: array
           description: The requirement for the image that user want to generate.

--- a/pilot-service-api.yaml
+++ b/pilot-service-api.yaml
@@ -216,6 +216,10 @@ components:
           type: string
           enum: [MALE, FEMALE, OTHER]
           description: Target demographic gender
+        target_custom_product_page:
+          type: string
+          enum: [APPLE_APP_CPP]
+          description: predefined formats of ads templates. APPLE_APP_CPP will include screenshot, app preview video, app icon, description, localized description. If set, image_configs will be ignored.
         image_configs:
           type: array
           description: The requirement for the image that user want to generate.


### PR DESCRIPTION
Based on customer's request, they want to support generate a predefined ads format.

Thus, we add a target_custom_product_page(target CPP) in the TargetContentConfig. This will simplify the process of setup.

The CPP we  support now is APPLE_APP_CPP which should include(may change in the future):
1. 10 static screenshots per type of devices.
2. Description of app less than 4000 characters.
3. App icon in 1024*1024 size
4. App preview video